### PR TITLE
Add quick sort algorithm and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 ![CI](https://github.com/kinksn/algorithms-ts/actions/workflows/ci.yml/badge.svg)
+
+# algorithms-ts
+
+A collection of basic algorithms implemented in TypeScript.
+
+## Setup
+
+Install dependencies with **pnpm** and run the test suite:
+
+```bash
+pnpm install
+pnpm exec vitest run
+```
+
+## Available algorithms
+
+- `mergeSorted(a, b)` – merge two sorted arrays.
+- `quickSort(arr)` – sort an array using Quick Sort.
+
+These functions are exported from `src/index.ts` so you can import them from the package root.
+

--- a/src/arrays/quickSort.test.ts
+++ b/src/arrays/quickSort.test.ts
@@ -1,0 +1,15 @@
+import { quickSort } from './quickSort';
+
+describe('quickSort', () => {
+  test('sorts an unsorted array', () => {
+    expect(quickSort([3, 1, 4, 1, 5, 9])).toEqual([1, 1, 3, 4, 5, 9]);
+  });
+
+  test('handles empty array', () => {
+    expect(quickSort([])).toEqual([]);
+  });
+
+  test('returns sorted array for already sorted input', () => {
+    expect(quickSort([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+});

--- a/src/arrays/quickSort.ts
+++ b/src/arrays/quickSort.ts
@@ -1,0 +1,17 @@
+/**
+ * Sort an array using Quick Sort.
+ * Time  : O(n log n) on average
+ * Space : O(n)
+ */
+
+export function quickSort(arr: number[]): number[] {
+  if (arr.length <= 1) return arr.slice();
+  const [pivot, ...rest] = arr;
+  const left: number[] = [];
+  const right: number[] = [];
+  for (const n of rest) {
+    if (n <= pivot) left.push(n);
+    else right.push(n);
+  }
+  return [...quickSort(left), pivot, ...quickSort(right)];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { mergeSorted } from './arrays/mergeSorted';
+export { quickSort } from './arrays/quickSort';


### PR DESCRIPTION
## Summary
- implement `quickSort` with a simple recursive algorithm
- test `quickSort`
- export `quickSort` from the package index
- document setup and available algorithms in the README

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68407002afc88330b6cc315af7cf2ee6