### PR TITLE
Add data structures and traversal algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ pnpm exec vitest run
 - `mergeSorted(a, b)` – merge two sorted arrays.
 - `quickSort(arr)` – sort an array using Quick Sort.
 - `binarySearch(arr, target)` – search for a number in a sorted array.
+- `heapSort(arr)` – sort an array using Heap Sort.
+- `SinglyLinkedList` – linked list with insert, delete and search.
+- `DoublyLinkedList` – doubly linked list with insert, delete and search.
+- `HashTable` – hash table with `set` and `get`.
+- `bfsTree(root)` – breadth-first search for binary trees.
+- `bfsGraph(graph, start)` – breadth-first search for graphs.
+- `dfsGraph(graph, start)` – depth-first search for graphs.
 
 These functions are exported from `src/index.ts` so you can import them from the package root.
-

--- a/src/arrays/heapSort.test.ts
+++ b/src/arrays/heapSort.test.ts
@@ -1,0 +1,11 @@
+import { heapSort } from './heapSort';
+
+describe('heapSort', () => {
+  test('sorts an array', () => {
+    expect(heapSort([4, 1, 3, 2])).toEqual([1, 2, 3, 4]);
+  });
+
+  test('handles empty array', () => {
+    expect(heapSort([])).toEqual([]);
+  });
+});

--- a/src/arrays/heapSort.ts
+++ b/src/arrays/heapSort.ts
@@ -1,0 +1,32 @@
+/**
+ * Sort an array using Heap Sort.
+ * Time  : O(n log n)
+ * Space : O(1)
+ */
+
+function heapify(a: number[], n: number, i: number): void {
+  let largest = i;
+  const left = 2 * i + 1;
+  const right = 2 * i + 2;
+
+  if (left < n && a[left] > a[largest]) largest = left;
+  if (right < n && a[right] > a[largest]) largest = right;
+
+  if (largest !== i) {
+    [a[i], a[largest]] = [a[largest], a[i]];
+    heapify(a, n, largest);
+  }
+}
+
+export function heapSort(arr: number[]): number[] {
+  const a = arr.slice();
+  const n = a.length;
+  for (let i = Math.floor(n / 2) - 1; i >= 0; i--) {
+    heapify(a, n, i);
+  }
+  for (let i = n - 1; i >= 0; i--) {
+    [a[0], a[i]] = [a[i], a[0]];
+    heapify(a, i, 0);
+  }
+  return a;
+}

--- a/src/graphs/bfsGraph.test.ts
+++ b/src/graphs/bfsGraph.test.ts
@@ -1,0 +1,13 @@
+import { bfsGraph } from './bfsGraph';
+
+describe('bfsGraph', () => {
+  test('traverses graph in BFS order', () => {
+    const graph = new Map<number, number[]>([
+      [1, [2, 3]],
+      [2, [4]],
+      [3, []],
+      [4, []],
+    ]);
+    expect(bfsGraph(graph, 1)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/src/graphs/bfsGraph.ts
+++ b/src/graphs/bfsGraph.ts
@@ -1,0 +1,25 @@
+/**
+ * Breadth-first search for graphs represented as adjacency lists.
+ * Time: O(V + E)
+ * Space: O(V)
+ */
+
+export function bfsGraph(graph: Map<number, number[]>, start: number): number[] {
+  const visited = new Set<number>();
+  const queue: number[] = [start];
+  const result: number[] = [];
+  visited.add(start);
+
+  while (queue.length) {
+    const node = queue.shift()!;
+    result.push(node);
+    for (const neighbor of graph.get(node) || []) {
+      if (!visited.has(neighbor)) {
+        visited.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/graphs/dfsGraph.test.ts
+++ b/src/graphs/dfsGraph.test.ts
@@ -1,0 +1,13 @@
+import { dfsGraph } from './dfsGraph';
+
+describe('dfsGraph', () => {
+  test('traverses graph in DFS order', () => {
+    const graph = new Map<number, number[]>([
+      [1, [2, 3]],
+      [2, [4]],
+      [3, []],
+      [4, []],
+    ]);
+    expect(dfsGraph(graph, 1)).toEqual([1, 2, 4, 3]);
+  });
+});

--- a/src/graphs/dfsGraph.ts
+++ b/src/graphs/dfsGraph.ts
@@ -1,0 +1,23 @@
+/**
+ * Depth-first search for graphs represented as adjacency lists.
+ * Time: O(V + E)
+ * Space: O(V)
+ */
+
+export function dfsGraph(graph: Map<number, number[]>, start: number): number[] {
+  const visited = new Set<number>();
+  const result: number[] = [];
+
+  function dfs(node: number): void {
+    visited.add(node);
+    result.push(node);
+    for (const neighbor of graph.get(node) || []) {
+      if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      }
+    }
+  }
+
+  dfs(start);
+  return result;
+}

--- a/src/hash/hashTable.test.ts
+++ b/src/hash/hashTable.test.ts
@@ -1,0 +1,14 @@
+import { HashTable } from './hashTable';
+
+describe('HashTable', () => {
+  test('sets and gets values', () => {
+    const ht = new HashTable<number>();
+    ht.set('a', 1);
+    expect(ht.get('a')).toBe(1);
+  });
+
+  test('returns undefined for missing key', () => {
+    const ht = new HashTable<number>();
+    expect(ht.get('x')).toBeUndefined();
+  });
+});

--- a/src/hash/hashTable.ts
+++ b/src/hash/hashTable.ts
@@ -1,0 +1,18 @@
+/**
+ * Basic hash table using JavaScript object for storage.
+ * Provides constant time set and get on average.
+ * Time: O(1) average for set and get.
+ * Space: O(n)
+ */
+
+export class HashTable<V> {
+  private data: Record<string, V> = {};
+
+  set(key: string, value: V): void {
+    this.data[key] = value;
+  }
+
+  get(key: string): V | undefined {
+    return this.data[key];
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
 export { mergeSorted } from './arrays/mergeSorted';
 export { quickSort } from './arrays/quickSort';
 export { binarySearch } from './arrays/binarySearch';
+export { heapSort } from './arrays/heapSort';
+export { SinglyLinkedList } from './lists/singlyLinkedList';
+export { DoublyLinkedList } from './lists/doublyLinkedList';
+export { HashTable } from './hash/hashTable';
+export { bfsTree } from './trees/bfsTree';
+export { bfsGraph } from './graphs/bfsGraph';
+export { dfsGraph } from './graphs/dfsGraph';

--- a/src/lists/doublyLinkedList.test.ts
+++ b/src/lists/doublyLinkedList.test.ts
@@ -1,0 +1,18 @@
+import { DoublyLinkedList } from './doublyLinkedList';
+
+describe('DoublyLinkedList', () => {
+  test('inserts and searches values', () => {
+    const list = new DoublyLinkedList<number>();
+    list.insert(1);
+    list.insert(2);
+    expect(list.search(1)?.value).toBe(1);
+  });
+
+  test('deletes a value', () => {
+    const list = new DoublyLinkedList<number>();
+    list.insert(1);
+    list.insert(2);
+    expect(list.delete(2)).toBe(true);
+    expect(list.search(2)).toBeNull();
+  });
+});

--- a/src/lists/doublyLinkedList.ts
+++ b/src/lists/doublyLinkedList.ts
@@ -1,0 +1,49 @@
+/**
+ * Doubly linked list implementation with basic operations.
+ * Insertion at end, deletion by value, and search.
+ * Time: O(n) for insertion, deletion, and search.
+ * Space: O(1)
+ */
+
+export class DoublyLinkedListNode<T> {
+  constructor(
+    public value: T,
+    public prev: DoublyLinkedListNode<T> | null = null,
+    public next: DoublyLinkedListNode<T> | null = null,
+  ) {}
+}
+
+export class DoublyLinkedList<T> {
+  head: DoublyLinkedListNode<T> | null = null;
+  tail: DoublyLinkedListNode<T> | null = null;
+
+  insert(value: T): void {
+    const node = new DoublyLinkedListNode(value, this.tail, null);
+    if (!this.head) {
+      this.head = this.tail = node;
+    } else {
+      if (this.tail) this.tail.next = node;
+      this.tail = node;
+    }
+  }
+
+  search(value: T): DoublyLinkedListNode<T> | null {
+    let curr = this.head;
+    while (curr) {
+      if (curr.value === value) return curr;
+      curr = curr.next;
+    }
+    return null;
+  }
+
+  delete(value: T): boolean {
+    let curr = this.head;
+    while (curr && curr.value !== value) {
+      curr = curr.next;
+    }
+    if (!curr) return false;
+    if (curr.prev) curr.prev.next = curr.next; else this.head = curr.next;
+    if (curr.next) curr.next.prev = curr.prev; else this.tail = curr.prev;
+    return true;
+  }
+}

--- a/src/lists/singlyLinkedList.test.ts
+++ b/src/lists/singlyLinkedList.test.ts
@@ -1,0 +1,18 @@
+import { SinglyLinkedList } from './singlyLinkedList';
+
+describe('SinglyLinkedList', () => {
+  test('inserts and searches values', () => {
+    const list = new SinglyLinkedList<number>();
+    list.insert(1);
+    list.insert(2);
+    expect(list.search(2)?.value).toBe(2);
+  });
+
+  test('deletes a value', () => {
+    const list = new SinglyLinkedList<number>();
+    list.insert(1);
+    list.insert(2);
+    expect(list.delete(1)).toBe(true);
+    expect(list.search(1)).toBeNull();
+  });
+});

--- a/src/lists/singlyLinkedList.ts
+++ b/src/lists/singlyLinkedList.ts
@@ -1,0 +1,54 @@
+/**
+ * Singly linked list implementation with basic operations.
+ * Insertion at end, deletion by value, and search.
+ * Time: O(n) for insertion, deletion, and search.
+ * Space: O(1)
+ */
+
+export class SinglyLinkedListNode<T> {
+  constructor(
+    public value: T,
+    public next: SinglyLinkedListNode<T> | null = null,
+  ) {}
+}
+
+export class SinglyLinkedList<T> {
+  head: SinglyLinkedListNode<T> | null = null;
+
+  insert(value: T): void {
+    const node = new SinglyLinkedListNode(value);
+    if (!this.head) {
+      this.head = node;
+      return;
+    }
+    let curr = this.head;
+    while (curr.next) curr = curr.next;
+    curr.next = node;
+  }
+
+  search(value: T): SinglyLinkedListNode<T> | null {
+    let curr = this.head;
+    while (curr) {
+      if (curr.value === value) return curr;
+      curr = curr.next;
+    }
+    return null;
+  }
+
+  delete(value: T): boolean {
+    if (!this.head) return false;
+    if (this.head.value === value) {
+      this.head = this.head.next;
+      return true;
+    }
+    let curr = this.head;
+    while (curr.next && curr.next.value !== value) {
+      curr = curr.next;
+    }
+    if (curr.next) {
+      curr.next = curr.next.next;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/trees/bfsTree.test.ts
+++ b/src/trees/bfsTree.test.ts
@@ -1,0 +1,16 @@
+import { bfsTree, TreeNode } from './bfsTree';
+
+describe('bfsTree', () => {
+  test('traverses tree in BFS order', () => {
+    const root: TreeNode<number> = {
+      value: 1,
+      left: { value: 2 },
+      right: { value: 3 },
+    };
+    expect(bfsTree(root)).toEqual([1, 2, 3]);
+  });
+
+  test('handles empty tree', () => {
+    expect(bfsTree<number>(null)).toEqual([]);
+  });
+});

--- a/src/trees/bfsTree.ts
+++ b/src/trees/bfsTree.ts
@@ -1,0 +1,24 @@
+/**
+ * Breadth-first search traversal for a binary tree.
+ * Time: O(n)
+ * Space: O(n)
+ */
+
+export interface TreeNode<T> {
+  value: T;
+  left?: TreeNode<T> | null;
+  right?: TreeNode<T> | null;
+}
+
+export function bfsTree<T>(root: TreeNode<T> | null): T[] {
+  const result: T[] = [];
+  if (!root) return result;
+  const queue: (TreeNode<T>)[] = [root];
+  while (queue.length) {
+    const node = queue.shift()!;
+    result.push(node.value);
+    if (node.left) queue.push(node.left);
+    if (node.right) queue.push(node.right);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add linked list implementations with tests
- add hash table implementation with tests
- implement BFS/DFS for graphs and BFS for trees with tests
- implement heap sort and tests
- export new algorithms from entry point
- document algorithms in README

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6843c30b90c88330a697ddf9be7b561e