### PR TITLE
Fix tsconfig to exclude tests from build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -111,5 +111,5 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": ["src/**/*"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- avoid compiling test files when running `tsc`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68406f859a688330a2aca29e47bdf9be